### PR TITLE
Fix normalized comparison semantics for QD types

### DIFF
--- a/include/qd/dd_inline.h
+++ b/include/qd/dd_inline.h
@@ -436,99 +436,166 @@ inline dd_real &dd_real::operator=(double a) {
 }
 
 /*********** Equality Comparisons ************/
+namespace qd {
+template <class A, class B>
+inline dd_real dd_comparison_difference(const A &a, const B &b) {
+  return dd_real(a) - dd_real(b);
+}
+
+template <class A, class B>
+inline bool dd_comparison_eq(const A &a, const B &b) {
+  dd_real da(a);
+  dd_real db(b);
+  if (da.isnan() || db.isnan())
+    return false;
+  if (da.isinf() || db.isinf())
+    return da.x[0] == db.x[0];
+  dd_real d = dd_comparison_difference(da, db);
+  return d.is_zero();
+}
+
+template <class A, class B>
+inline bool dd_comparison_lt(const A &a, const B &b) {
+  dd_real da(a);
+  dd_real db(b);
+  if (da.isnan() || db.isnan())
+    return false;
+  if (da.isinf() || db.isinf())
+    return da.x[0] < db.x[0];
+  dd_real d = dd_comparison_difference(da, db);
+  return d.is_negative();
+}
+
+template <class A, class B>
+inline bool dd_comparison_gt(const A &a, const B &b) {
+  dd_real da(a);
+  dd_real db(b);
+  if (da.isnan() || db.isnan())
+    return false;
+  if (da.isinf() || db.isinf())
+    return da.x[0] > db.x[0];
+  dd_real d = dd_comparison_difference(da, db);
+  return d.is_positive();
+}
+
+template <class A, class B>
+inline bool dd_comparison_le(const A &a, const B &b) {
+  dd_real da(a);
+  dd_real db(b);
+  if (da.isnan() || db.isnan())
+    return false;
+  if (da.isinf() || db.isinf())
+    return da.x[0] <= db.x[0];
+  dd_real d = dd_comparison_difference(da, db);
+  return d.is_zero() || d.is_negative();
+}
+
+template <class A, class B>
+inline bool dd_comparison_ge(const A &a, const B &b) {
+  dd_real da(a);
+  dd_real db(b);
+  if (da.isnan() || db.isnan())
+    return false;
+  if (da.isinf() || db.isinf())
+    return da.x[0] >= db.x[0];
+  dd_real d = dd_comparison_difference(da, db);
+  return d.is_zero() || d.is_positive();
+}
+}
+
 /* double-double == double */
 inline bool operator==(const dd_real &a, double b) {
-  return (a.x[0] == b && a.x[1] == 0.0);
+  return qd::dd_comparison_eq(a, b);
 }
 
 /* double-double == double-double */
 inline bool operator==(const dd_real &a, const dd_real &b) {
-  return (a.x[0] == b.x[0] && a.x[1] == b.x[1]);
+  return qd::dd_comparison_eq(a, b);
 }
 
 /* double == double-double */
 inline bool operator==(double a, const dd_real &b) {
-  return (a == b.x[0] && b.x[1] == 0.0);
+  return qd::dd_comparison_eq(a, b);
 }
 
 /*********** Greater-Than Comparisons ************/
 /* double-double > double */
 inline bool operator>(const dd_real &a, double b) {
-  return (a.x[0] > b || (a.x[0] == b && a.x[1] > 0.0));
+  return qd::dd_comparison_gt(a, b);
 }
 
 /* double-double > double-double */
 inline bool operator>(const dd_real &a, const dd_real &b) {
-  return (a.x[0] > b.x[0] || (a.x[0] == b.x[0] && a.x[1] > b.x[1]));
+  return qd::dd_comparison_gt(a, b);
 }
 
 /* double > double-double */
 inline bool operator>(double a, const dd_real &b) {
-  return (a > b.x[0] || (a == b.x[0] && b.x[1] < 0.0));
+  return qd::dd_comparison_gt(a, b);
 }
 
 /*********** Less-Than Comparisons ************/
 /* double-double < double */
 inline bool operator<(const dd_real &a, double b) {
-  return (a.x[0] < b || (a.x[0] == b && a.x[1] < 0.0));
+  return qd::dd_comparison_lt(a, b);
 }
 
 /* double-double < double-double */
 inline bool operator<(const dd_real &a, const dd_real &b) {
-  return (a.x[0] < b.x[0] || (a.x[0] == b.x[0] && a.x[1] < b.x[1]));
+  return qd::dd_comparison_lt(a, b);
 }
 
 /* double < double-double */
 inline bool operator<(double a, const dd_real &b) {
-  return (a < b.x[0] || (a == b.x[0] && b.x[1] > 0.0));
+  return qd::dd_comparison_lt(a, b);
 }
 
 /*********** Greater-Than-Or-Equal-To Comparisons ************/
 /* double-double >= double */
 inline bool operator>=(const dd_real &a, double b) {
-  return (a.x[0] > b || (a.x[0] == b && a.x[1] >= 0.0));
+  return qd::dd_comparison_ge(a, b);
 }
 
 /* double-double >= double-double */
 inline bool operator>=(const dd_real &a, const dd_real &b) {
-  return (a.x[0] > b.x[0] || (a.x[0] == b.x[0] && a.x[1] >= b.x[1]));
+  return qd::dd_comparison_ge(a, b);
 }
 
 /* double >= double-double */
 inline bool operator>=(double a, const dd_real &b) {
-  return (b <= a);
+  return qd::dd_comparison_ge(a, b);
 }
 
 /*********** Less-Than-Or-Equal-To Comparisons ************/
 /* double-double <= double */
 inline bool operator<=(const dd_real &a, double b) {
-  return (a.x[0] < b || (a.x[0] == b && a.x[1] <= 0.0));
+  return qd::dd_comparison_le(a, b);
 }
 
 /* double-double <= double-double */
 inline bool operator<=(const dd_real &a, const dd_real &b) {
-  return (a.x[0] < b.x[0] || (a.x[0] == b.x[0] && a.x[1] <= b.x[1]));
+  return qd::dd_comparison_le(a, b);
 }
 
 /* double <= double-double */
 inline bool operator<=(double a, const dd_real &b) {
-  return (b >= a);
+  return qd::dd_comparison_le(a, b);
 }
 
 /*********** Not-Equal-To Comparisons ************/
 /* double-double != double */
 inline bool operator!=(const dd_real &a, double b) {
-  return (a.x[0] != b || a.x[1] != 0.0);
+  return !(a == b);
 }
 
 /* double-double != double-double */
 inline bool operator!=(const dd_real &a, const dd_real &b) {
-  return (a.x[0] != b.x[0] || a.x[1] != b.x[1]);
+  return !(a == b);
 }
 
 /* double != double-double */
 inline bool operator!=(double a, const dd_real &b) {
-  return (a != b.x[0] || b.x[1] != 0.0);
+  return !(a == b);
 }
 
 /*********** Micellaneous ************/

--- a/include/qd/qd_inline.h
+++ b/include/qd/qd_inline.h
@@ -819,132 +819,179 @@ inline qd_real &qd_real::operator=(const dd_real &a) {
 }
 
 /********** Equality Comparison **********/
+namespace qd {
+template <class A, class B>
+inline qd_real comparison_difference(const A &a, const B &b) {
+  qd_real d = qd_real(a) - qd_real(b);
+  d.renorm();
+  return d;
+}
+
+template <class A, class B>
+inline bool comparison_eq(const A &a, const B &b) {
+  qd_real qa(a);
+  qd_real qb(b);
+  if (qa.isnan() || qb.isnan())
+    return false;
+  if (qa.isinf() || qb.isinf())
+    return qa[0] == qb[0];
+  qd_real d = comparison_difference(qa, qb);
+  return d.is_zero();
+}
+
+template <class A, class B>
+inline bool comparison_lt(const A &a, const B &b) {
+  qd_real qa(a);
+  qd_real qb(b);
+  if (qa.isnan() || qb.isnan())
+    return false;
+  if (qa.isinf() || qb.isinf())
+    return qa[0] < qb[0];
+  qd_real d = comparison_difference(qa, qb);
+  return d.is_negative();
+}
+
+template <class A, class B>
+inline bool comparison_gt(const A &a, const B &b) {
+  qd_real qa(a);
+  qd_real qb(b);
+  if (qa.isnan() || qb.isnan())
+    return false;
+  if (qa.isinf() || qb.isinf())
+    return qa[0] > qb[0];
+  qd_real d = comparison_difference(qa, qb);
+  return d.is_positive();
+}
+
+template <class A, class B>
+inline bool comparison_le(const A &a, const B &b) {
+  qd_real qa(a);
+  qd_real qb(b);
+  if (qa.isnan() || qb.isnan())
+    return false;
+  if (qa.isinf() || qb.isinf())
+    return qa[0] <= qb[0];
+  qd_real d = comparison_difference(qa, qb);
+  return d.is_zero() || d.is_negative();
+}
+
+template <class A, class B>
+inline bool comparison_ge(const A &a, const B &b) {
+  qd_real qa(a);
+  qd_real qb(b);
+  if (qa.isnan() || qb.isnan())
+    return false;
+  if (qa.isinf() || qb.isinf())
+    return qa[0] >= qb[0];
+  qd_real d = comparison_difference(qa, qb);
+  return d.is_zero() || d.is_positive();
+}
+}
+
 inline bool operator==(const qd_real &a, double b) {
-  return (a[0] == b && a[1] == 0.0 && a[2] == 0.0 && a[3] == 0.0);
+  return qd::comparison_eq(a, b);
 }
 
 inline bool operator==(double a, const qd_real &b) {
-  return (b == a);
+  return qd::comparison_eq(a, b);
 }
 
 inline bool operator==(const qd_real &a, const dd_real &b) {
-  return (a[0] == b._hi() && a[1] == b._lo() && 
-          a[2] == 0.0 && a[3] == 0.0);
+  return qd::comparison_eq(a, b);
 }
 
 inline bool operator==(const dd_real &a, const qd_real &b) {
-  return (b == a);
+  return qd::comparison_eq(a, b);
 }
 
 inline bool operator==(const qd_real &a, const qd_real &b) {
-  return (a[0] == b[0] && a[1] == b[1] && 
-          a[2] == b[2] && a[3] == b[3]);
+  return qd::comparison_eq(a, b);
 }
 
 
 /********** Less-Than Comparison ***********/
 inline bool operator<(const qd_real &a, double b) {
-  return (a[0] < b || (a[0] == b && a[1] < 0.0));
+  return qd::comparison_lt(a, b);
 }
 
 inline bool operator<(double a, const qd_real &b) {
-  return (b > a);
+  return qd::comparison_lt(a, b);
 }
 
 inline bool operator<(const qd_real &a, const dd_real &b) {
-  return (a[0] < b._hi() || 
-          (a[0] == b._hi() && (a[1] < b._lo() ||
-                            (a[1] == b._lo() && a[2] < 0.0))));
+  return qd::comparison_lt(a, b);
 }
 
 inline bool operator<(const dd_real &a, const qd_real &b) {
-  return (b > a);
+  return qd::comparison_lt(a, b);
 }
 
 inline bool operator<(const qd_real &a, const qd_real &b) {
-  return (a[0] < b[0] ||
-          (a[0] == b[0] && (a[1] < b[1] ||
-                            (a[1] == b[1] && (a[2] < b[2] ||
-                                              (a[2] == b[2] && a[3] < b[3]))))));
+  return qd::comparison_lt(a, b);
 }
 
 /********** Greater-Than Comparison ***********/
 inline bool operator>(const qd_real &a, double b) {
-  return (a[0] > b || (a[0] == b && a[1] > 0.0));
+  return qd::comparison_gt(a, b);
 }
 
 inline bool operator>(double a, const qd_real &b) {
-  return (b < a);
+  return qd::comparison_gt(a, b);
 }
 
 inline bool operator>(const qd_real &a, const dd_real &b) {
-  return (a[0] > b._hi() || 
-          (a[0] == b._hi() && (a[1] > b._lo() ||
-                            (a[1] == b._lo() && a[2] > 0.0))));
+  return qd::comparison_gt(a, b);
 }
 
 inline bool operator>(const dd_real &a, const qd_real &b) {
-  return (b < a);
+  return qd::comparison_gt(a, b);
 }
 
 inline bool operator>(const qd_real &a, const qd_real &b) {
-  return (a[0] > b[0] ||
-          (a[0] == b[0] && (a[1] > b[1] ||
-                            (a[1] == b[1] && (a[2] > b[2] ||
-                                              (a[2] == b[2] && a[3] > b[3]))))));
+  return qd::comparison_gt(a, b);
 }
 
 
 /********** Less-Than-Or-Equal-To Comparison **********/
 inline bool operator<=(const qd_real &a, double b) {
-  return (a[0] < b || (a[0] == b && a[1] <= 0.0));
+  return qd::comparison_le(a, b);
 }
 
 inline bool operator<=(double a, const qd_real &b) {
-  return (b >= a);
+  return qd::comparison_le(a, b);
 }
 
 inline bool operator<=(const qd_real &a, const dd_real &b) {
-  return (a[0] < b._hi() || 
-          (a[0] == b._hi() && (a[1] < b._lo() || 
-                            (a[1] == b._lo() && a[2] <= 0.0))));
+  return qd::comparison_le(a, b);
 }
 
 inline bool operator<=(const dd_real &a, const qd_real &b) {
-  return (b >= a);
+  return qd::comparison_le(a, b);
 }
 
 inline bool operator<=(const qd_real &a, const qd_real &b) {
-  return (a[0] < b[0] || 
-          (a[0] == b[0] && (a[1] < b[1] ||
-                            (a[1] == b[1] && (a[2] < b[2] ||
-                                              (a[2] == b[2] && a[3] <= b[3]))))));
+  return qd::comparison_le(a, b);
 }
 
 /********** Greater-Than-Or-Equal-To Comparison **********/
 inline bool operator>=(const qd_real &a, double b) {
-  return (a[0] > b || (a[0] == b && a[1] >= 0.0));
+  return qd::comparison_ge(a, b);
 }
 
 inline bool operator>=(double a, const qd_real &b) {
-  return (b <= a);
+  return qd::comparison_ge(a, b);
 }
 
 inline bool operator>=(const qd_real &a, const dd_real &b) {
-  return (a[0] > b._hi() || 
-          (a[0] == b._hi() && (a[1] > b._lo() || 
-                            (a[1] == b._lo() && a[2] >= 0.0))));
+  return qd::comparison_ge(a, b);
 }
 
 inline bool operator>=(const dd_real &a, const qd_real &b) {
-  return (b <= a);
+  return qd::comparison_ge(a, b);
 }
 
 inline bool operator>=(const qd_real &a, const qd_real &b) {
-  return (a[0] > b[0] || 
-          (a[0] == b[0] && (a[1] > b[1] ||
-                            (a[1] == b[1] && (a[2] > b[2] ||
-                                              (a[2] == b[2] && a[3] >= b[3]))))));
+  return qd::comparison_ge(a, b);
 }
 
 

--- a/tests/qd_test.cpp
+++ b/tests/qd_test.cpp
@@ -949,6 +949,67 @@ bool TestSuite<T>::test8() {
   return (delta < 4.0 * T::_eps);
 }
 
+bool test_qd_real_comparison() {
+  cout << endl;
+  cout << "Test 9.  (qd_real comparison normalization)." << endl;
+
+  qd_real a(1.0, 0.5, 0.0, 0.0);
+  qd_real b(1.5);
+  qd_real diff = a - b;
+  diff.renorm();
+
+  bool pass = diff.is_zero();
+  pass &= (a == b);
+  pass &= !(a != b);
+  pass &= !(a < b);
+  pass &= !(a > b);
+  pass &= (a <= b);
+  pass &= (a >= b);
+
+  pass &= (a == 1.5);
+  pass &= (1.5 == a);
+  pass &= (a == dd_real(1.5));
+  pass &= (dd_real(1.5) == a);
+
+  if (flag_verbose) {
+    cout << "a = [" << a[0] << ", " << a[1] << ", "
+         << a[2] << ", " << a[3] << "]" << endl;
+    cout << "b = " << b << endl;
+    cout << "renormalized diff is zero: " << diff.is_zero() << endl;
+  }
+
+  return pass;
+}
+
+bool test_dd_real_comparison() {
+  cout << endl;
+  cout << "Test 9.  (dd_real comparison normalization)." << endl;
+
+  double lo = std::ldexp(1.0, -53);
+  dd_real a(1.0 - lo, lo);
+  dd_real b(1.0);
+  dd_real diff = a - b;
+
+  bool pass = diff.is_zero();
+  pass &= (a == b);
+  pass &= !(a != b);
+  pass &= !(a < b);
+  pass &= !(a > b);
+  pass &= (a <= b);
+  pass &= (a >= b);
+
+  pass &= (a == 1.0);
+  pass &= (1.0 == a);
+
+  if (flag_verbose) {
+    cout << "a = [" << a._hi() << ", " << a._lo() << "]" << endl;
+    cout << "b = " << b << endl;
+    cout << "diff is zero: " << diff.is_zero() << endl;
+  }
+
+  return pass;
+}
+
 template <class T>
 bool TestSuite<T>::testall() {
   bool pass = true;
@@ -1021,6 +1082,7 @@ int main(int argc, char *argv[]) {
     if (flag_verbose)
       cout << "sizeof(dd_real) = " << sizeof(dd_real) << endl;
     pass &= dd_test.testall();
+    pass &= print_result(test_dd_real_comparison());
   }
 
   if (flag_test_qd) {
@@ -1031,6 +1093,7 @@ int main(int argc, char *argv[]) {
     if (flag_verbose)
       cout << "sizeof(qd_real) = " << sizeof(qd_real) << endl;
     pass &= qd_test.testall();
+    pass &= print_result(test_qd_real_comparison());
   }
 
   if (flag_test_td) {


### PR DESCRIPTION
Fix comparison operators for `dd_real` and `qd_real` so values with different
  component layouts but the same exact normalized value compare equal.

  Previously, equality compared internal components directly. For example:

  ```cpp
  qd_real a(1.0, 0.5, 0.0, 0.0);
  qd_real b(1.5);

  These represent the same value, but the old implementation compared the raw
  components, so a == b returned false.

  The same issue can happen for dd_real:

  double lo = std::ldexp(1.0, -53);
  dd_real a(1.0 - lo, lo);
  dd_real b(1.0);

  Here a - b is exactly zero after normalization, but direct component
  comparison can still report the values as unequal.

  This PR changes comparisons to use exact normalized-difference semantics rather
  than raw component equality or tolerance-based equality.

  ## Changes

  - Update qd_real comparison operators to compare via exact renormalized difference.
  - Update dd_real comparison operators to compare via exact normalized difference.
  - Route <, >, <=, and >= through the same comparison path so ordering stays consistent with equality.
  - Preserve NaN and infinity behavior by handling those cases before subtraction.
  - Add focused regression tests for structurally different but numerically equal dd_real and qd_real values.

  ## Validation

  Ran:

  make -C tests qd_test
  ./tests/qd_test

  All tests passed.

  ## Notes

  This does not introduce tolerance-based equality. Equality remains exact after
  QD/DD normalization.